### PR TITLE
Routes: removes unnecessary dashboard route

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ The bus dashboard displays groups of buses at stops. If you have a few stops clo
 
 ### Authentication:
 
+- `/signup`
 - `/login`
 - `/logout`
 - `/reset`
 
 ### App CRUD routes:
-
-- GET `/dashboard` -- this is the view where we add/delete/update groups. It should also have a search box.
 
 Groups:
 


### PR DESCRIPTION
This PR removes the unnecessary `/dashboard` route from the planned API routes. It should be handled by the front end, not the API.