### PR TITLE
Feature groups routes

### DIFF
--- a/daos/groups.js
+++ b/daos/groups.js
@@ -73,21 +73,20 @@ module.exports.getUserIdFromGroupId = async (groupId) => {
     }
 };
 
-module.exports.getById = async (groupId) => {
+module.exports.getByIdAndUserId = async (groupId, userId) => {
     try {
-        const group = await Group.findOne({ _id: groupId }).lean();
+        const group = await Group.findOne({ _id: groupId, userId: userId }).lean();
         return group;
     } catch (e) {
         throw e;
     }
 };
 
-module.exports.updateById = async (groupId, name, origin, destination, isDefault) => {
+module.exports.updateById = async (groupId, name, origin, destination) => {
     let updateObj = {};
     if (name) { updateObj.name = name};
     if (origin) { updateObj.origin = origin};
     if (destination) { updateObj.destination = destination};
-    if (isDefault) { updateObj.isDefault = isDefault}
 
     try {
         const updatedGroup = await Group.update({ _id: groupId }, updateObj);
@@ -98,5 +97,10 @@ module.exports.updateById = async (groupId, name, origin, destination, isDefault
 };
 
 module.exports.deleteById = async (groupId) => {
-    await Group.remove({ _id: groupId });
+    if (!mongoose.Types.ObjectId.isValid(groupId)) {
+        return false;
+      } else {
+        await Group.deleteOne({ _id: groupId });
+        return true;
+      }
 }

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -94,7 +94,6 @@ module.exports.updateById = async (groupId, origin, destination, isDefault) => {
                 "isDefault": isDefault
                 }
             }
- 
         );
         return updatedGroup
     } catch (e) {

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -88,9 +88,13 @@ module.exports.updateById = async (groupId, origin, destination, isDefault) => {
     try {
         const updatedGroup = await Group.update(
             { _id: groupId },
-            {  origin: origin },
-            { destination: destination},
-            { isDefault: isDefault}
+            { $set: {
+                "origin": origin,
+                "destination": destination,
+                "isDefault": isDefault
+                }
+            }
+ 
         );
         return updatedGroup
     } catch (e) {

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -4,4 +4,45 @@ const Group = require('../models/group');
 
 module.exports = {};
 
+module.exports.create = async(userId, origin, destination, isDefault) => {
+    try {
+        const newGroup = await Group.create({
+            userId: userId,
+            origin: origin,
+            destination: destination,
+            isDefault: isDefault
+        });
+        return newGroup
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.getByOrigin = async () => {};
+
+module.exports.getByDestination = async () => {};
+
+module.exports.getByOriginAndDestination = async () => {};
+
+module.exports.getByOriginAndDestination = async () => {};
+
+module.exports.getByUserId = async () => {};
+
+module.exports.getAssociatedUserId = async () => {};
+
+module.exports.getById = async () => {};
+
+module.exports.updateById = async () => {};
+
+module.exports.deleteById = async (groupId) => {
+    const validId = await mongoose.Types.ObjectId.isValid(groupId);
+    try{
+        if (validId) {
+            await Group.remove({ _id: groupId })
+        }
+    } catch (e) {
+        throw e;
+    }
+}
+
 // DAO operations

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -11,7 +11,6 @@ module.exports.create = async(userId, name, origin, destination, isDefault) => {
             name: name,
             origin: origin,
             destination: destination,
-            isDefault: isDefault
         });
         return newGroup;
     } catch (e) {

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -18,31 +18,90 @@ module.exports.create = async(userId, origin, destination, isDefault) => {
     }
 };
 
-module.exports.getByOrigin = async () => {};
+module.exports.getByOrigin = async (origin) => {
+    try {
+        const originResults = await Group.find(
+            { $text: { $search: origin } },
+            { score: { $meta: "textScore" } }
+            ).sort({ score: { $meta: "textScore" } }).lean();
+        return originResults;
+    } catch (e) {
+        throw e;
+    }
+};
 
-module.exports.getByDestination = async () => {};
+module.exports.getByDestination = async () => {
+    try {
+        const destinationResults = await Group.find(
+            { $text: { $search: destination } },
+            { score: { $meta: "textScore" } }
+            ).sort({ score: { $meta: "textScore" } }).lean();
+        return destinationResults;
+    } catch (e) {
+        throw e;
+    }
+};
 
-module.exports.getByOriginAndDestination = async () => {};
+module.exports.getByOriginAndDestination = async (searchString) => {
+    try {
+        const searchResults = await Group.find(
+            { $text: { $search: searchString } },
+            { score: { $meta: "textScore" } }
+            ).sort({ score: { $meta: "textScore" } }).lean();
+        return searchResults;
+    } catch (e) {
+        throw e;
+    }
+};
 
-module.exports.getByOriginAndDestination = async () => {};
+module.exports.getByUserId = async (userId) => {
+    try {
+        const groups = await Group.find({ userId: userId}).lean();
+        return groups
+    } catch (e) {
+        throw e;
+    }
+};
 
-module.exports.getByUserId = async () => {};
-
-module.exports.getAssociatedUserId = async () => {};
-
-module.exports.getById = async () => {};
-
-module.exports.updateById = async () => {};
-
-module.exports.deleteById = async (groupId) => {
+module.exports.getAssociatedUserId = async (groupId) => {
     const validId = await mongoose.Types.ObjectId.isValid(groupId);
-    try{
+    try {
         if (validId) {
-            await Group.remove({ _id: groupId })
+            const group = await Group.findOne({ _id: groupId });
+            return group.userId
         }
     } catch (e) {
         throw e;
     }
-}
+};
 
-// DAO operations
+module.exports.getById = async (groupId) => {
+    try {
+        const group = await Group.findOne({ _id: groupId }).lean();
+        return group
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.updateById = async (groupId, origin, destination, isDefault) => {
+    try {
+        const updatedGroup = await Group.update(
+            { _id: groupId },
+            {  origin: origin },
+            { destination: destination},
+            { isDefault: isDefault}
+        );
+        return updatedGroup
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.deleteById = async (groupId) => {
+    try{
+        await Group.remove({ _id: groupId })
+    } catch (e) {
+        throw e;
+    }
+}

--- a/daos/groups.js
+++ b/daos/groups.js
@@ -4,15 +4,16 @@ const Group = require('../models/group');
 
 module.exports = {};
 
-module.exports.create = async(userId, origin, destination, isDefault) => {
+module.exports.create = async(userId, name, origin, destination, isDefault) => {
     try {
         const newGroup = await Group.create({
             userId: userId,
+            name: name,
             origin: origin,
             destination: destination,
             isDefault: isDefault
         });
-        return newGroup
+        return newGroup;
     } catch (e) {
         throw e;
     }
@@ -30,7 +31,7 @@ module.exports.getByOrigin = async (origin) => {
     }
 };
 
-module.exports.getByDestination = async () => {
+module.exports.getByDestination = async (destination) => {
     try {
         const destinationResults = await Group.find(
             { $text: { $search: destination } },
@@ -57,19 +58,16 @@ module.exports.getByOriginAndDestination = async (searchString) => {
 module.exports.getByUserId = async (userId) => {
     try {
         const groups = await Group.find({ userId: userId}).lean();
-        return groups
+        return groups;
     } catch (e) {
         throw e;
     }
 };
 
-module.exports.getAssociatedUserId = async (groupId) => {
-    const validId = await mongoose.Types.ObjectId.isValid(groupId);
+module.exports.getUserIdFromGroupId = async (groupId) => {
     try {
-        if (validId) {
-            const group = await Group.findOne({ _id: groupId });
-            return group.userId
-        }
+        const group = await Group.findOne({ _id: groupId });
+        return group.userId;
     } catch (e) {
         throw e;
     }
@@ -78,33 +76,27 @@ module.exports.getAssociatedUserId = async (groupId) => {
 module.exports.getById = async (groupId) => {
     try {
         const group = await Group.findOne({ _id: groupId }).lean();
-        return group
+        return group;
     } catch (e) {
         throw e;
     }
 };
 
-module.exports.updateById = async (groupId, origin, destination, isDefault) => {
+module.exports.updateById = async (groupId, name, origin, destination, isDefault) => {
+    let updateObj = {};
+    if (name) { updateObj.name = name};
+    if (origin) { updateObj.origin = origin};
+    if (destination) { updateObj.destination = destination};
+    if (isDefault) { updateObj.isDefault = isDefault}
+
     try {
-        const updatedGroup = await Group.update(
-            { _id: groupId },
-            { $set: {
-                "origin": origin,
-                "destination": destination,
-                "isDefault": isDefault
-                }
-            }
-        );
-        return updatedGroup
+        const updatedGroup = await Group.update({ _id: groupId }, updateObj);
+        return updatedGroup;
     } catch (e) {
         throw e;
     }
 };
 
 module.exports.deleteById = async (groupId) => {
-    try{
-        await Group.remove({ _id: groupId })
-    } catch (e) {
-        throw e;
-    }
+    await Group.remove({ _id: groupId });
 }

--- a/models/group.js
+++ b/models/group.js
@@ -2,9 +2,12 @@ const mongoose = require('mongoose');
 
 const groupSchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'users', required: true },
-    origin: { type: String, required: true, text: true },
-    destination: { type: String, required: true, text: true },
-    isDefault: { type: Boolean, default: false, required: true}
+    name: { type: String, required: true },
+    origin: { type: String },
+    destination: { type: String },
+    isDefault: { type: Boolean, default: false }
 });
+
+groupSchema.index({ name: 'text', origin: 'text', destination: 'text' });
 
 module.exports = mongoose.model("groups", groupSchema);

--- a/models/group.js
+++ b/models/group.js
@@ -1,7 +1,10 @@
 const mongoose = require('mongoose');
 
 const groupSchema = new mongoose.Schema({
-    // to complete
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: 'users', required: true },
+    origin: { type: String, required: true },
+    destination: { type: String, required: true },
+    isDefault: { type: Boolean, default: false, required: true}
 });
 
 module.exports = mongoose.model("groups", groupSchema);

--- a/models/group.js
+++ b/models/group.js
@@ -2,8 +2,8 @@ const mongoose = require('mongoose');
 
 const groupSchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'users', required: true },
-    origin: { type: String, required: true },
-    destination: { type: String, required: true },
+    origin: { type: String, required: true, text: true },
+    destination: { type: String, required: true, text: true },
     isDefault: { type: Boolean, default: false, required: true}
 });
 

--- a/models/group.js
+++ b/models/group.js
@@ -4,8 +4,7 @@ const groupSchema = new mongoose.Schema({
     userId: { type: mongoose.Schema.Types.ObjectId, ref: 'users', required: true },
     name: { type: String, required: true },
     origin: { type: String },
-    destination: { type: String },
-    isDefault: { type: Boolean, default: false }
+    destination: { type: String }
 });
 
 groupSchema.index({ name: 'text', origin: 'text', destination: 'text' });

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -1,27 +1,122 @@
-const { Router, query } = require("express");
+const { Router, query, response } = require("express");
 const router = Router();
+
+const groupDAO = require('../daos/groups');
 
 // Authentication middleware
 
 // Routes
-router.post("/", async (req, res, next) => {
-    // to complete
-});
+router.post("/",
+    // authentication middleware, 
+    async (req, res, next) => {
+        const userId = req.user._id;
+        const { origin, destination, isDefault } = req.body;
+        const newGroup = await groupDAO.create(userId, origin, destination, isDefault);
+        if (newGroup) {
+            res.json(newGroup);
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
-router.get("/", async (req, res, next) => {
-    // to complete
-});
+router.get("/", 
+    // authentication middleware, 
+    async (req, res, next) => {
+        let { origin, destination } = req.query;
+        if (origin) {
+            const groups = await groupDAO.getByOrigin(origin);
+            if (groups) {
+                res.json(groups);
+            } else {
+                res.sendStatus(404);
+            }
+        } else if (destination) {
+            const groups = await groupDAO.getByDestination(destination);
+            if (groups) {
+                res.json(groups);
+            } else {
+                res.sendStatus(404);
+            }
+        } else if (origin && destination) {
+            const groups = await groupDAO.getByOriginAndDestination(origin, destination);
+            if (groups) {
+                res.json(groups);
+            } else {
+                res.sendStatus(404);
+            }
+        } else {
+            const userId = req.user._id;
+            const groups = await groupDAO.getByUserId(userId);
+            if (groups) {
+                res.json(groups);
+            } else {
+                res.sendStatus(404);
+            }
+        }
+    }
+);
 
-router.get("/:id", async (req, res, next) => {
-    // to complete
-});
+router.get("/:id",
+    // authentication middleware, 
+    async (req, res, next) => {
+        const groupId = req.params.id;
+        if (groupId) {
+            const userId = req.user._id;
+            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            if (userId == storedUserId) {
+                const group = await groupDAO.getById(groupId);
+                res.json(group)
+            } else {
+                res.sendStatus(404);
+            }
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
-router.put("/:id", async (req, res, next) => {
-    // to complete
-});
+router.put("/:id",
+    // authentication middleware, 
+    async (req, res, next) => {
+        const groupId = req.params.id;
+        if (groupId) {
+            const userId = req.user._id;
+            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            if (userId == storedUserId) {
+                const { origin, destination, isDefault } = req.body;
+                const updatedGroup = await groupDAO.updateById(groupId, origin, destination, isDefault)
+                if (updatedGroup) {
+                    res.json(updatedGroup);
+                } else {
+                    res.sendStatus(404);
+                }
+            } else {
+                res.sendStatus(404);
+            }       
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
-router.delete("/:id", async (req, res, next) => {
-    // to complete
-});
+router.delete("/:id",
+    // authentication middleware, 
+    async (req, res, next) => {
+        const groupId = req.params.id;
+        if (groupId) {
+            const userId = req.user._id;
+            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            if (userId == storedUserId) {
+                await groupDAO.deleteById(groupId);
+                res.sendStatus(200);
+            } else {
+                res.sendStatus(404);
+            }            
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
 module.exports = router;

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -59,9 +59,8 @@ router.get("/:id",
     async (req, res, next) => {
         const groupId = req.params.id;
         if (groupId) {
-            const storedUserId = await groupDAO.getUserIdFromGroupId(groupId);
-            if (req.userId == storedUserId) {
-                const group = await groupDAO.getById(groupId);
+            const group = await groupDAO.getByIdAndUserId(groupId, req.userId);
+            if (group) {
                 res.json(group)
             } else {
                 res.sendStatus(404);
@@ -103,11 +102,11 @@ router.delete("/:id",
             const storedUserId = await groupDAO.getUserIdFromGroupId(groupId);
             if (req.userId == storedUserId) {
                 try {
-                    await groupDAO.deleteById(groupId);
-                    res.sendStatus(200);
-                } catch (e) {
+                    const success = await groupDAO.deleteById(groupId);
+                    res.sendStatus(success ? 200 : 400);
+                  } catch(e) {
                     res.status(500).send(e.message);
-                }
+                  }
             } else {
                 res.sendStatus(404);
             }            

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -39,7 +39,8 @@ router.get("/",
                 res.sendStatus(404);
             }
         } else if (origin && destination) {
-            const groups = await groupDAO.getByOriginAndDestination(origin, destination);
+            const searchString = `${origin} ${destination}`;
+            const groups = await groupDAO.getByOriginAndDestination(searchString);
             if (groups) {
                 res.json(groups);
             } else {
@@ -63,12 +64,12 @@ router.get("/:id",
         const groupId = req.params.id;
         if (groupId) {
             const userId = req.user._id;
-            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            const storedUserId = await groupDAO.getAssociatedUserId(groupId);
             if (userId == storedUserId) {
                 const group = await groupDAO.getById(groupId);
                 res.json(group)
             } else {
-                res.sendStatus(404);
+                res.sendStatus(403);
             }
         } else {
             res.sendStatus(404);
@@ -82,7 +83,7 @@ router.put("/:id",
         const groupId = req.params.id;
         if (groupId) {
             const userId = req.user._id;
-            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            const storedUserId = await groupDAO.getAssociatedUserId(groupId);
             if (userId == storedUserId) {
                 const { origin, destination, isDefault } = req.body;
                 const updatedGroup = await groupDAO.updateById(groupId, origin, destination, isDefault)
@@ -92,7 +93,7 @@ router.put("/:id",
                     res.sendStatus(404);
                 }
             } else {
-                res.sendStatus(404);
+                res.sendStatus(403);
             }       
         } else {
             res.sendStatus(404);
@@ -106,12 +107,12 @@ router.delete("/:id",
         const groupId = req.params.id;
         if (groupId) {
             const userId = req.user._id;
-            const storedUserId = await groupDAO.getAssociatedUserId(userId);
+            const storedUserId = await groupDAO.getAssociatedUserId(groupId);
             if (userId == storedUserId) {
                 await groupDAO.deleteById(groupId);
                 res.sendStatus(200);
             } else {
-                res.sendStatus(404);
+                res.sendStatus(403);
             }            
         } else {
             res.sendStatus(404);

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -1,4 +1,4 @@
-const { Router, query, response } = require("express");
+const { Router, query } = require("express");
 const router = Router();
 const { isAuthorized } = require("./middleware.js")
 

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -24,14 +24,14 @@ router.get("/",
     // authentication middleware, 
     async (req, res, next) => {
         let { origin, destination } = req.query;
-        if (origin) {
+        if (origin && !destination) {
             const groups = await groupDAO.getByOrigin(origin);
             if (groups) {
                 res.json(groups);
             } else {
                 res.sendStatus(404);
             }
-        } else if (destination) {
+        } else if (destination && !origin) {
             const groups = await groupDAO.getByDestination(destination);
             if (groups) {
                 res.json(groups);
@@ -69,7 +69,7 @@ router.get("/:id",
                 const group = await groupDAO.getById(groupId);
                 res.json(group)
             } else {
-                res.sendStatus(403);
+                res.sendStatus(404);
             }
         } else {
             res.sendStatus(404);
@@ -93,7 +93,7 @@ router.put("/:id",
                     res.sendStatus(404);
                 }
             } else {
-                res.sendStatus(403);
+                res.sendStatus(404);
             }       
         } else {
             res.sendStatus(404);
@@ -112,7 +112,7 @@ router.delete("/:id",
                 await groupDAO.deleteById(groupId);
                 res.sendStatus(200);
             } else {
-                res.sendStatus(403);
+                res.sendStatus(404);
             }            
         } else {
             res.sendStatus(404);

--- a/routes/groups.test.js
+++ b/routes/groups.test.js
@@ -13,9 +13,9 @@ describe("/groups", () => {
     afterEach(testUtils.clearDB);
 
     const group0 = { name: "group0", origin: "Seattle", destination: "Portland" };
-    const group1 = { name: "group1", origin: "New York", destination: "Boston", isDefault: true };
+    const group1 = { name: "group1", origin: "New York", destination: "Boston" };
     const group2 = { name: "group2", origin: "Portland", destination: "Seattle" };
-    const group3 = { name: "group3", origin: "Boston", destination: "New York", isDefault: true };
+    const group3 = { name: "group3", origin: "Boston", destination: "New York" };
 
     describe('Before login', () => {
       describe('POST /', () => {
@@ -275,8 +275,7 @@ describe("/groups", () => {
               expect(storedGroup).toMatchObject({
                 name: "newName0",
                 origin: "Seattle",
-                destination: "Portland",
-                isDefault: false
+                destination: "Portland"
               })
             });
             it.each([0, 1])('should not update user0 group #%# from user1', async (index) => {
@@ -301,8 +300,7 @@ describe("/groups", () => {
               expect(storedGroup).toMatchObject({
                 name: "newName1",
                 origin: "Portland",
-                destination: "newDestination",
-                isDefault: false
+                destination: "newDestination"
               })
             });
             it.each([0, 1])('should not update user1 group #%# from user0', async (index) => {
@@ -334,6 +332,11 @@ describe("/groups", () => {
                 .set('Authorization', 'Bearer ' + token0)
                 .send();
               expect(res.statusCode).toEqual(200);
+              const storedGroupResponse = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(storedGroupResponse.status).toEqual(404);
             });
             it.each([0, 1])('should not allow user0 to delete group from user1', async (index) => {
               const group = user1Groups[index];
@@ -355,6 +358,11 @@ describe("/groups", () => {
                 .set('Authorization', 'Bearer ' + token1)
                 .send();
               expect(res.statusCode).toEqual(200);
+              const storedGroupResponse = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(storedGroupResponse.status).toEqual(404);
             });
             it.each([0, 1])('should not allow user1 to delete group from user0', async (index) => {
               const group = user0Groups[index];

--- a/routes/groups.test.js
+++ b/routes/groups.test.js
@@ -12,280 +12,365 @@ describe("/groups", () => {
   
     afterEach(testUtils.clearDB);
 
-    const group0 = { origin: "Seattle", destination: "Portland" };
-    const group1 = { origin: "New York", destination: "Boston", isDefault: true };
-    const group2 = { origin: "Portland", destination: "Seattle" };
-    const group3 = { origin: "Boston", destination: "New York", isDefault: true };
+    const group0 = { name: "group0", origin: "Seattle", destination: "Portland" };
+    const group1 = { name: "group1", origin: "New York", destination: "Boston", isDefault: true };
+    const group2 = { name: "group2", origin: "Portland", destination: "Seattle" };
+    const group3 = { name: "group3", origin: "Boston", destination: "New York", isDefault: true };
 
+    describe('Before login', () => {
+      describe('POST /', () => {
+        it('should send 401 without a token', async () => {
+          const res = await request(server).post("/groups").send(group0);
+          expect(res.statusCode).toEqual(401);
+        });
+        it('should send 401 with a bad token', async () => {
+          const res = await request(server)
+            .post("/groups")
+            .set('Authorization', 'Bearer BAD')
+            .send(group0);
+          expect(res.statusCode).toEqual(401);
+        });
+      });
+      describe('GET /', () => {
+        it('should send 401 without a token', async () => {
+          const res = await request(server).get("/groups").send();
+          expect(res.statusCode).toEqual(401);
+        });
+        it('should send 401 with a bad token', async () => {
+          const res = await request(server)
+            .get("/groups")
+            .set('Authorization', 'Bearer BAD')
+            .send();
+          expect(res.statusCode).toEqual(401);
+        });
+      });
+      describe('GET /:id', () => {
+        it('should send 401 without a token', async () => {
+          const res = await request(server).get("/groups/123").send();
+          expect(res.statusCode).toEqual(401);
+        });
+        it('should send 401 with a bad token', async () => {
+          const res = await request(server)
+            .get("/groups/456")
+            .set('Authorization', 'Bearer BAD')
+            .send();
+          expect(res.statusCode).toEqual(401);
+        });
+      });
+      describe('PUT /:id', () => {
+        it('should send 401 without a token', async () => {
+          const res = await request(server).put("/groups/123").send();
+          expect(res.statusCode).toEqual(401);
+        });
+        it('should send 401 with a bad token', async () => {
+          const res = await request(server)
+            .put("/groups/456")
+            .set('Authorization', 'Bearer BAD')
+            .send();
+          expect(res.statusCode).toEqual(401);
+        });
+      });
+      describe('DELETE /:id', () => {
+        it('should send 401 without a token', async () => {
+          const res = await request(server).delete("/groups/123").send();
+          expect(res.statusCode).toEqual(401);
+        });
+        it('should send 401 with a bad token', async () => {
+          const res = await request(server)
+            .delete("/groups/456")
+            .set('Authorization', 'Bearer BAD')
+            .send();
+          expect(res.statusCode).toEqual(401);
+        });
+      });
+    });
     describe('after login', () => {
-        const user0 = {
-            email: 'user0@mail.com',
-            password: '123password'
-          };
-          const user1 = {
-            email: 'user1@mail.com',
-            password: '456password'
-          }
-        //   let token0;
-        //   let token1;
+      const user0 = {
+          email: 'user0@mail.com',
+          password: '123password'
+        };
+        const user1 = {
+          email: 'user1@mail.com',
+          password: '456password'
+        }
+        let token0;
+        let token1;
+        beforeEach(async () => {
+          await request(server).post("/login/signup").send(user0);
+          const res0 = await request(server).post("/login").send(user0);
+          token0 = res0.body.token;
+          await request(server).post("/login/signup").send(user1);
+          const res1 = await request(server).post("/login").send(user1);
+          token1 = res1.body.token;
+        });
+        describe('POST /', () => {
+          it('should send 200', async () => {
+              const res = await request(server)
+                .post("/groups")
+                .set('Authorization', 'Bearer ' + token0)
+                .send(group0);
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toMatchObject(group0)
+            });
+            it('should store group with userId for user0', async () => {
+              await request(server)
+                .post("/groups")
+                .set('Authorization', 'Bearer ' + token0)
+                .send(group0);
+              const user = await User.findOne({email: user0.email}).lean();
+              const savedGroup = await Group.findOne({ userId: user._id }).lean();
+              expect(savedGroup).toMatchObject(group0);
+            });
+            it('should store group with userId for user1', async () => {
+              await request(server)
+                .post("/groups")
+                .set('Authorization', 'Bearer ' + token1)
+                .send(group1);
+              const user = await User.findOne({email: user1.email}).lean();
+              const savedGroup = await Group.findOne({ userId: user._id }).lean();
+              expect(savedGroup).toMatchObject(group1);
+            });
+        });
+        describe('GET /', () => {
+          let user0Groups;
+          let user1Groups;
           beforeEach(async () => {
-            // await request(server).post("/login/signup").send(user0);
-            // const res0 = await request(server).post("/login").send(user0);
-            // token0 = res0.body.token;
-            // await request(server).post("/login/signup").send(user1);
-            // const res1 = await request(server).post("/login").send(user1);
-            // token1 = res1.body.token;
+            user0Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+            ];
+            user1Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+            ];
           });
-          describe('POST /', () => {
-            it('should send 200', async () => {
-                const res = await request(server)
-                  .post("/groups")
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send(group0);
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toMatchObject(group0)
-              });
-              it('should store group with userId', async () => {
-                await request(server)
-                  .post("/groups")
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send(group0);
-                const user = await User.findOne({email: user0.email}).lean();
-                const savedGroup = await Group.findOne({ userId: user._id }).lean();
-                expect(savedGroup).toMatchObject(group0);
-              });
-              it('should store group with userId for user1', async () => {
-                await request(server)
-                  .post("/notes")
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send(group1);
-                const user = await User.findOne({email: user1.email}).lean();
-                const savedGroup = await Group.findOne({ userId: user._id }).lean();
-                expect(savedGroup).toMatchObject(group1);
-              });
-          });
-          describe('GET /', () => {
-            let user0Groups;
-            let user1Groups;
-            beforeEach(async () => {
-              user0Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
-              ];
-              user1Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
-              ];
+          it('should return user0 only their groups', async () => {
+              const res = await request(server)
+                .get("/groups")
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toEqual(user0Groups)
             });
-            it('should return user0 only their groups', async () => {
-                const res = await request(server)
-                  .get("/groups")
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toEqual(user0Groups)
-              });
-              it('should return user1 only their groups', async () => {
-                const res = await request(server)
-                  .get("/groups")
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toEqual(user1Groups)
-              });
-              it("should return multiple matching groups sorted by best score, for origin query", async () => {
-                const searchTerm = 'Seattle'
-                const res = await request(server).get("/groups?origin=" + encodeURI(searchTerm));
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toMatchObject([
-                    // reflect what I see in postman
-                ]);
-              });
-              it("should return multiple matching groups sorted by best score, for destination query", async () => {
-                const searchTerm = 'Boston'
-                const res = await request(server).get("/groups?destination=" + encodeURI(searchTerm));
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toMatchObject([
-                    // reflect what I see in postman
-                ]);
-              });
-              it("should return multiple matching groups sorted by best score, for origin & destination query", async () => {
-                const searchTerm0 = 'Boston';
-                const searchTerm1 = 'Seattle';
-                const res = await request(server).get("/groups?origin=" + encodeURI(searchTerm0) + "?destination=" + encodeURI(searchTerm1));
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toMatchObject([
-                    // reflect what I see in postman
-                ]);
-              });
-          });
-          describe('GET /:id', () => {
-            let user0Groups;
-            let user1Groups;
-            beforeEach(async () => {
-              user0Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
-              ];
-              user1Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
-              ];
+            it('should return user1 only their groups', async () => {
+              const res = await request(server)
+                .get("/groups")
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toEqual(user1Groups)
             });
-            it.each([0, 1])('should return user0 group #%#', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .get("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toEqual(group);
-              });
-              it.each([0, 1])('should not return user0 group #%# from user1', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .get("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-              });
-              it.each([0, 1])('should return user1 group #%#', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .get("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                expect(res.body).toEqual(group);
-              });
-              it.each([0, 1])('should not return user1 group #%# from user0', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .get("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-              });
-          });
-          describe('PUT /:id', () => {
-            let user0Group;
-            let user1Group;
-            beforeEach(async () => {
-              user0Groups = [
-                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
-                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
-              ];
-              user1Groups = [
-                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
-                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
-              ];
+            it("should return multiple matching groups sorted by best score, for origin query", async () => {
+              const searchTerm = 'Seattle'
+              const res = await request(server)
+                .get("/groups?origin=" + encodeURI(searchTerm))
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toMatchObject([
+                user0Groups[0],
+                user1Groups[0]
+              ]);
             });
-            it.each([0, 1])('should update user0 group #%#', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .put("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send({ origin: 'newoOrigin' });
-                expect(res.statusCode).toEqual(200);
-                const storedEvent = (await request(server).get("/groups/" + group._id)).body;
-                expect(storedGroup).toMatchObject({
-                    // fill in desired object output
-                })
-              });
-              it.each([0, 1])('should not update user0 group #%# from user1', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .put("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-              });
-              it.each([0, 1])('should update user1 group #%#', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .put("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send({ destination: 'newDestination' });
-                expect(res.statusCode).toEqual(200);
-                const storedEvent = (await request(server).get("/groups/" + group._id)).body;
-                expect(storedGroup).toMatchObject({
-                    // fill in desired object output
-                })
-              });
-              it.each([0, 1])('should not update user1 group #%# from user0', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .put("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-              });
-          });
-          describe('DELETE /:id', () => {
-            let user0Groups;
-            let user1Groups;
-            beforeEach(async () => {
-              user0Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
-              ];
-              user1Groups = [
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
-                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
-              ];
+            it("should return multiple matching groups sorted by best score, for destination query", async () => {
+              const searchTerm = 'Boston'
+              const res = await request(server)
+                .get("/groups?destination=" + encodeURI(searchTerm))
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toMatchObject([
+                // this part has issues
+                user0Groups[1],
+                user1Groups[1]
+              ]);
             });
-            it.each([0, 1])('should delete user0 group #%#', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .delete("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                const storedGroupResponse = (await request(server)
-                    .get("/groups/" + group._id)
-                    // .set('Authorization', 'Bearer ' + token0)
-                    .send());
-                expect(storedGroupResponse.status).toEqual(404);
-              });
-              it.each([0, 1])('should not allow user0 to delete group from user1', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .delete("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token0)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-                const storedGroupResponse = (await request(server)
-                    .get("/groups/" + group._id)
-                    // .set('Authorization', 'Bearer ' + token1)
-                    .send());
-                expect(storedGroupResponse.status).toEqual(200);
-              });
-              it.each([0, 1])('should delete user1 group #%#', async (index) => {
-                const group = user1Groups[index];
-                const res = await request(server)
-                  .delete("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(200);
-                const storedGroupResponse = (await request(server)
-                    .get("/groups/" + group._id)
-                    // .set('Authorization', 'Bearer ' + token1)
-                    .send());
-                expect(storedGroupResponse.status).toEqual(404);
-              });
-              it.each([0, 1])('should not allow user1 to delete group from user0', async (index) => {
-                const group = user0Groups[index];
-                const res = await request(server)
-                  .delete("/groups/" + group._id)
-                //   .set('Authorization', 'Bearer ' + token1)
-                  .send();
-                expect(res.statusCode).toEqual(404);
-                const storedGroupResponse = (await request(server)
-                    .get("/groups/" + group._id)
-                    // .set('Authorization', 'Bearer ' + token0)
-                    .send());
-                expect(storedGroupResponse.status).toEqual(200);
-              });
+            it("should return multiple matching groups sorted by best score, for origin & destination query", async () => {
+              const searchTerm0 = 'Boston';
+              const searchTerm1 = 'Seattle';
+              const res = await request(server)
+                .get("/groups?origin=" + encodeURI(searchTerm0) + "?destination=" + encodeURI(searchTerm1))
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toMatchObject([
+                // this part has issues
+                user0Groups[1],
+                user1Groups[1],
+                user0Groups[0],
+                user1Groups[0]
+              ]);
+            });
+        });
+        describe('GET /:id', () => {
+          let user0Groups;
+          let user1Groups;
+          beforeEach(async () => {
+            user0Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+            ];
+            user1Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+            ];
           });
+          it.each([0, 1])('should return user0 group #%#', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toEqual(group);
+            });
+            it.each([0, 1])('should not return user0 group #%# from user1', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(404);
+            });
+            it.each([0, 1])('should return user1 group #%#', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(200);
+              expect(res.body).toEqual(group);
+            });
+            it.each([0, 1])('should not return user1 group #%# from user0', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(404);
+            });
+        });
+        describe('PUT /:id', () => {
+          let user0Group;
+          let user1Group;
+          beforeEach(async () => {
+            user0Groups = [
+                (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+                (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+            ];
+            user1Groups = [
+                (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+                (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+            ];
+          });
+          it.each([0])('should update user0 group #%#', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .put("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send({ name: 'newName0' });
+              expect(res.statusCode).toEqual(200);
+              const storedGroup = (await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send()).body;
+              expect(storedGroup).toMatchObject({
+                name: "newName0",
+                origin: "Seattle",
+                destination: "Portland",
+                isDefault: false
+              })
+            });
+            it.each([0, 1])('should not update user0 group #%# from user1', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .put("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(404);
+            });
+            it.each([0])('should update user1 group #%#', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .put("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send({ name: 'newName1', destination: 'newDestination' });
+              expect(res.statusCode).toEqual(200);
+              const storedGroup = (await request(server)
+                .get("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send()).body;
+              expect(storedGroup).toMatchObject({
+                name: "newName1",
+                origin: "Portland",
+                destination: "newDestination",
+                isDefault: false
+              })
+            });
+            it.each([0, 1])('should not update user1 group #%# from user0', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .put("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(404);
+            });
+        });
+        describe('DELETE /:id', () => {
+          let user0Groups;
+          let user1Groups;
+          beforeEach(async () => {
+            user0Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+            ];
+            user1Groups = [
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+              (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+            ];
+          });
+          it.each([0, 1])('should delete user0 group #%#', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .delete("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(200);
+            });
+            it.each([0, 1])('should not allow user0 to delete group from user1', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .delete("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token0)
+                .send();
+              expect(res.statusCode).toEqual(404);
+              const storedGroupResponse = (await request(server)
+                  .get("/groups/" + group._id)
+                  .set('Authorization', 'Bearer ' + token1)
+                  .send());
+              expect(storedGroupResponse.status).toEqual(200);
+            });
+            it.each([0, 1])('should delete user1 group #%#', async (index) => {
+              const group = user1Groups[index];
+              const res = await request(server)
+                .delete("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(200);
+            });
+            it.each([0, 1])('should not allow user1 to delete group from user0', async (index) => {
+              const group = user0Groups[index];
+              const res = await request(server)
+                .delete("/groups/" + group._id)
+                .set('Authorization', 'Bearer ' + token1)
+                .send();
+              expect(res.statusCode).toEqual(404);
+              const storedGroupResponse = (await request(server)
+                  .get("/groups/" + group._id)
+                  .set('Authorization', 'Bearer ' + token0)
+                  .send());
+              expect(storedGroupResponse.status).toEqual(200);
+            });
+        });
     });
 });

--- a/routes/groups.test.js
+++ b/routes/groups.test.js
@@ -180,7 +180,6 @@ describe("/groups", () => {
                 .send();
               expect(res.statusCode).toEqual(200);
               expect(res.body).toMatchObject([
-                // this part has issues
                 user0Groups[1],
                 user1Groups[1]
               ]);
@@ -194,7 +193,6 @@ describe("/groups", () => {
                 .send();
               expect(res.statusCode).toEqual(200);
               expect(res.body).toMatchObject([
-                // this part has issues
                 user0Groups[1],
                 user1Groups[1],
                 user0Groups[0],

--- a/routes/groups.test.js
+++ b/routes/groups.test.js
@@ -3,12 +3,289 @@ const request = require("supertest");
 const server = require("../server");
 const testUtils = require('../test-utils');
 
+const User = require('../models/user');
+const Group = require('../models/group');
+
 describe("/groups", () => {
     beforeAll(testUtils.connectDB);
     afterAll(testUtils.stopDB);
   
     afterEach(testUtils.clearDB);
 
-    // to complete
+    const group0 = { origin: "Seattle", destination: "Portland" };
+    const group1 = { origin: "New York", destination: "Boston", isDefault: true };
+    const group2 = { origin: "Portland", destination: "Seattle" };
+    const group3 = { origin: "Boston", destination: "New York", isDefault: true };
 
+    describe('after login', () => {
+        const user0 = {
+            email: 'user0@mail.com',
+            password: '123password'
+          };
+          const user1 = {
+            email: 'user1@mail.com',
+            password: '456password'
+          }
+        //   let token0;
+        //   let token1;
+          beforeEach(async () => {
+            // await request(server).post("/login/signup").send(user0);
+            // const res0 = await request(server).post("/login").send(user0);
+            // token0 = res0.body.token;
+            // await request(server).post("/login/signup").send(user1);
+            // const res1 = await request(server).post("/login").send(user1);
+            // token1 = res1.body.token;
+          });
+          describe('POST /', () => {
+            it('should send 200', async () => {
+                const res = await request(server)
+                  .post("/groups")
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send(group0);
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toMatchObject(group0)
+              });
+              it('should store group with userId', async () => {
+                await request(server)
+                  .post("/groups")
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send(group0);
+                const user = await User.findOne({email: user0.email}).lean();
+                const savedGroup = await Group.findOne({ userId: user._id }).lean();
+                expect(savedGroup).toMatchObject(group0);
+              });
+              it('should store group with userId for user1', async () => {
+                await request(server)
+                  .post("/notes")
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send(group1);
+                const user = await User.findOne({email: user1.email}).lean();
+                const savedGroup = await Group.findOne({ userId: user._id }).lean();
+                expect(savedGroup).toMatchObject(group1);
+              });
+          });
+          describe('GET /', () => {
+            let user0Groups;
+            let user1Groups;
+            beforeEach(async () => {
+              user0Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+              ];
+              user1Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+              ];
+            });
+            it('should return user0 only their groups', async () => {
+                const res = await request(server)
+                  .get("/groups")
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toEqual(user0Groups)
+              });
+              it('should return user1 only their groups', async () => {
+                const res = await request(server)
+                  .get("/groups")
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toEqual(user1Groups)
+              });
+              it("should return multiple matching groups sorted by best score, for origin query", async () => {
+                const searchTerm = 'Seattle'
+                const res = await request(server).get("/groups?origin=" + encodeURI(searchTerm));
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toMatchObject([
+                    // reflect what I see in postman
+                ]);
+              });
+              it("should return multiple matching groups sorted by best score, for destination query", async () => {
+                const searchTerm = 'Boston'
+                const res = await request(server).get("/groups?destination=" + encodeURI(searchTerm));
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toMatchObject([
+                    // reflect what I see in postman
+                ]);
+              });
+              it("should return multiple matching groups sorted by best score, for origin & destination query", async () => {
+                const searchTerm0 = 'Boston';
+                const searchTerm1 = 'Seattle';
+                const res = await request(server).get("/groups?origin=" + encodeURI(searchTerm0) + "?destination=" + encodeURI(searchTerm1));
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toMatchObject([
+                    // reflect what I see in postman
+                ]);
+              });
+          });
+          describe('GET /:id', () => {
+            let user0Groups;
+            let user1Groups;
+            beforeEach(async () => {
+              user0Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+              ];
+              user1Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+              ];
+            });
+            it.each([0, 1])('should return user0 group #%#', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .get("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toEqual(group);
+              });
+              it.each([0, 1])('should not return user0 group #%# from user1', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .get("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+              });
+              it.each([0, 1])('should return user1 group #%#', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .get("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toEqual(group);
+              });
+              it.each([0, 1])('should not return user1 group #%# from user0', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .get("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+              });
+          });
+          describe('PUT /:id', () => {
+            let user0Group;
+            let user1Group;
+            beforeEach(async () => {
+              user0Groups = [
+                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+              ];
+              user1Groups = [
+                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+                  // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+              ];
+            });
+            it.each([0, 1])('should update user0 group #%#', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .put("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send({ origin: 'newoOrigin' });
+                expect(res.statusCode).toEqual(200);
+                const storedEvent = (await request(server).get("/groups/" + group._id)).body;
+                expect(storedGroup).toMatchObject({
+                    // fill in desired object output
+                })
+              });
+              it.each([0, 1])('should not update user0 group #%# from user1', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .put("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+              });
+              it.each([0, 1])('should update user1 group #%#', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .put("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send({ destination: 'newDestination' });
+                expect(res.statusCode).toEqual(200);
+                const storedEvent = (await request(server).get("/groups/" + group._id)).body;
+                expect(storedGroup).toMatchObject({
+                    // fill in desired object output
+                })
+              });
+              it.each([0, 1])('should not update user1 group #%# from user0', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .put("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+              });
+          });
+          describe('DELETE /:id', () => {
+            let user0Groups;
+            let user1Groups;
+            beforeEach(async () => {
+              user0Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group1)).body,
+              ];
+              user1Groups = [
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group2)).body,
+                // (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group3)).body,
+              ];
+            });
+            it.each([0, 1])('should delete user0 group #%#', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .delete("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                const storedGroupResponse = (await request(server)
+                    .get("/groups/" + group._id)
+                    // .set('Authorization', 'Bearer ' + token0)
+                    .send());
+                expect(storedGroupResponse.status).toEqual(404);
+              });
+              it.each([0, 1])('should not allow user0 to delete group from user1', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .delete("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token0)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+                const storedGroupResponse = (await request(server)
+                    .get("/groups/" + group._id)
+                    // .set('Authorization', 'Bearer ' + token1)
+                    .send());
+                expect(storedGroupResponse.status).toEqual(200);
+              });
+              it.each([0, 1])('should delete user1 group #%#', async (index) => {
+                const group = user1Groups[index];
+                const res = await request(server)
+                  .delete("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(200);
+                const storedGroupResponse = (await request(server)
+                    .get("/groups/" + group._id)
+                    // .set('Authorization', 'Bearer ' + token1)
+                    .send());
+                expect(storedGroupResponse.status).toEqual(404);
+              });
+              it.each([0, 1])('should not allow user1 to delete group from user0', async (index) => {
+                const group = user0Groups[index];
+                const res = await request(server)
+                  .delete("/groups/" + group._id)
+                //   .set('Authorization', 'Bearer ' + token1)
+                  .send();
+                expect(res.statusCode).toEqual(404);
+                const storedGroupResponse = (await request(server)
+                    .get("/groups/" + group._id)
+                    // .set('Authorization', 'Bearer ' + token0)
+                    .send());
+                expect(storedGroupResponse.status).toEqual(200);
+              });
+          });
+    });
 });


### PR DESCRIPTION
This PR covers:

- `/groups` CRUD routes, including text search based on `origin` and or `destination` queries
- `/groups` modal including necessary indexing
- `/groups` DAO
- test suite

It does not cover:
- validation that a user can have only one `isDefault` group

Disclaimer:
I was trying to refactor a couple things that are not pretty right now but that only ended up causing breakage. If you have suggestions for how to make this more neat, please feel free to leave a comment.