### PR TITLE
Feature stops routes

### DIFF
--- a/daos/groups.js
+++ b/daos/groups.js
@@ -96,10 +96,10 @@ module.exports.updateById = async (groupId, name, origin, destination) => {
 };
 
 module.exports.deleteById = async (groupId) => {
-    if (!mongoose.Types.ObjectId.isValid(groupId)) {
-        return false;
-      } else {
+    try {
         await Group.deleteOne({ _id: groupId });
         return true;
-      }
+    } catch {
+        return false;
+    }  
 }

--- a/daos/stops.js
+++ b/daos/stops.js
@@ -12,6 +12,9 @@ module.exports.create = async(groupId, stopId) => {
         });
         return newStop;
     } catch (e) {
+        if (e.message.includes('duplicate key')) {
+            throw new BadDataError(e.message);
+        }
         throw e;
     }
 };
@@ -64,3 +67,6 @@ module.exports.deleteById = async (stopId) => {
         return false;
     }
 }
+
+class BadDataError extends Error {};
+module.exports.BadDataError = BadDataError;

--- a/daos/stops.js
+++ b/daos/stops.js
@@ -4,4 +4,63 @@ const Stop = require('../models/stop');
 
 module.exports = {};
 
-// DAO operations
+module.exports.create = async(groupId, stopId) => {
+    try {
+        const newStop = await Stop.create({
+            groupId: groupId,
+            stopId: stopId
+        });
+        return newStop;
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.getByGroupId = async (groupId) => {
+    try {
+        const stops = await Stop.find({ groupId: groupId }).lean();
+        return stops;
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.getAll = async () => {
+    try {
+        const stops = await Stop.find({}).lean();
+        return stops;
+    } catch (e) {
+        throw e;
+    }
+};
+
+module.exports.getById = async (id) => {
+    try {
+        const stops = await Stop.findOne({ _id: id }).lean();
+        return stops;
+    } catch (e) {
+        throw e;
+    }
+}
+
+module.exports.updateById = async (id, groupId, stopId) => {
+    let updateObj = {};
+    if (groupId) { updateObj.groupId = groupId};
+    if (stopId) { updateObj.stopId = stopId};
+
+    try {
+        const updatedStop = await Stop.update({ _id: id }, updateObj);
+        return updatedStop;
+    } catch (e) {
+        throw e;
+    }
+}
+
+module.exports.deleteById = async (stopId) => {
+    try{
+        await Stop.deleteOne({ _id: stopId });
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/models/authentication.js
+++ b/models/authentication.js
@@ -1,7 +1,0 @@
-const mongoose = require('mongoose');
-
-const authenticationSchema = new mongoose.Schema({
-    // to complete
-});
-
-module.exports = mongoose.model("authentications", authenticationSchema);

--- a/models/stop.js
+++ b/models/stop.js
@@ -1,7 +1,16 @@
 const mongoose = require('mongoose');
 
 const stopSchema = new mongoose.Schema({
-    // to complete
+    groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'groups', required: true },
+    stopId: {
+        type     : Number,
+        required : true,
+        unique   : true,
+        validate : {
+          validator : Number.isInteger,
+          message   : '{VALUE} is not an integer value'
+        }
+      }
 });
 
 module.exports = mongoose.model("stops", stopSchema);

--- a/models/stop.js
+++ b/models/stop.js
@@ -2,15 +2,9 @@ const mongoose = require('mongoose');
 
 const stopSchema = new mongoose.Schema({
     groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'groups', required: true },
-    stopId: {
-        type     : Number,
-        required : true,
-        unique   : true,
-        validate : {
-          validator : Number.isInteger,
-          message   : '{VALUE} is not an integer value'
-        }
-      }
+    stopId: { type: String, required : true}
 });
+
+stopSchema.index({ groupId: 1, stopId: 1 }, { unique: true });
 
 module.exports = mongoose.model("stops", stopSchema);

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -1,3 +1,5 @@
+const mongoose = require('mongoose');
+
 const tokenDAO = require('../daos/token');
 
 const isAuthorized = async (req, res, next) => {
@@ -29,5 +31,16 @@ const emailAndPassword = async (req, res, next) => {
     next();
   }
 }
+
+const isValidId = async (req, res, next) => {
+  const id = req.params.id;
+  if (!mongoose.Types.ObjectId.isValid(id)){
+    res.status(400).send('Must pass in valid Id')
+  } else {
+    next();
+  }
+}
+
 exports.isAuthorized = isAuthorized;
 exports.emailAndPassword = emailAndPassword;
+exports.isValidId = isValidId;

--- a/routes/stops.js
+++ b/routes/stops.js
@@ -8,11 +8,11 @@ router.post("/",
     isAuthorized,
     async (req, res, next) => {
         const { groupId, stopId } = req.body;
-        const newStop = await stopDAO.create(groupId, stopId);
-        if (newStop) {
+        try {
+            const newStop = await stopDAO.create(groupId, stopId);
             res.json(newStop);
-        } else {
-            res.sendStatus(404);
+        } catch(e) {
+            next(e);
         }
     }
 );
@@ -81,5 +81,14 @@ router.delete("/:id",
         }
     }
 );
+
+// errors
+router.use(async (error, req, res, next) => {
+    if (error instanceof stopDAO.BadDataError) {
+      res.status(409).send(error.message);
+    } else {
+      res.status(500).send('something went wrong');
+    }
+});
 
 module.exports = router;

--- a/routes/stops.js
+++ b/routes/stops.js
@@ -1,27 +1,85 @@
 const { Router, query } = require("express");
 const router = Router();
+const { isAuthorized, isValidId } = require("./middleware.js")
 
-// Authentication middleware
+const stopDAO = require('../daos/stops');
 
-// Routes
-router.post("/", async (req, res, next) => {
-    // to complete
-});
+router.post("/",
+    isAuthorized,
+    async (req, res, next) => {
+        const { groupId, stopId } = req.body;
+        const newStop = await stopDAO.create(groupId, stopId);
+        if (newStop) {
+            res.json(newStop);
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
-router.get("/", async (req, res, next) => {
-    // to complete
-});
+router.get("/",
+    isAuthorized,    
+    async (req, res, next) => {
+        let { groupId } = req.query;
+        if (groupId) {
+            const stops = await stopDAO.getByGroupId(groupId);
+            if (stops) {
+                res.json(stops);
+            } else {
+                res.sendStatus(404);
+            }
+        } else {
+            const stops = await stopDAO.getAll();
+            if (stops) {
+                res.json(stops);
+            } else {
+                res.sendStatus(404);
+            }
+        }
+    }
+);
 
-router.get("/:id", async (req, res, next) => {
-    // to complete
-});
+router.get("/:id",
+    isAuthorized,
+    isValidId,
+    async (req, res, next) => {
+        const id = req.params.id;
+        const stop = await stopDAO.getById(id);
+        if (stop) {
+            res.json(stop)
+        } else {
+            res.sendStatus(404);
+        }
+    }
+);
 
-router.put("/:id", async (req, res, next) => {
-    // to complete
-});
+router.put("/:id",
+    isAuthorized,
+    isValidId,
+    async (req, res, next) => {
+        const id = req.params.id;
+        const {groupId, stopId} = req.body;
+        const updatedStop = await stopDAO.updateById(id, groupId, stopId);
+        if (updatedStop) {
+            res.json(updatedStop)
+        } else {
+            res.sendStatus(404)
+        }
+    }
+);
 
-router.delete("/:id", async (req, res, next) => {
-    // to complete
-});
+router.delete("/:id",
+    isAuthorized,
+    isValidId,
+    async (req, res, next) => {
+        const id = req.params.id;
+        try {
+            const success = await stopDAO.deleteById(id);
+            res.sendStatus(success ? 200 : 400);
+        } catch(e) {
+            res.status(500).send(e.message);
+        }
+    }
+);
 
 module.exports = router;

--- a/routes/stops.test.js
+++ b/routes/stops.test.js
@@ -9,6 +9,9 @@ describe("/stops", () => {
   
     afterEach(testUtils.clearDB);
 
+    const group0 = { name: "group0", origin: "Seattle", destination: "Portland" };
+    const group1 = { name: "group1", origin: "New York", destination: "Boston" };
+
     describe('Before login', () => {
         describe('POST /', () => {
           it('should send 401 without a token', async () => {
@@ -87,6 +90,10 @@ describe("/stops", () => {
         }
         let token0;
         let token1;
+        let user0Group;
+        let user1Group;
+        let stop0;
+        let stop1;
         beforeEach(async () => {
             await request(server).post("/login/signup").send(user0);
             const res0 = await request(server).post("/login").send(user0);
@@ -94,7 +101,155 @@ describe("/stops", () => {
             await request(server).post("/login/signup").send(user1);
             const res1 = await request(server).post("/login").send(user1);
             token1 = res1.body.token;
+
+            user0Group = (await request(server).post("/groups").set('Authorization', 'Bearer ' + token0).send(group0)).body;
+            user1Group = (await request(server).post("/groups").set('Authorization', 'Bearer ' + token1).send(group1)).body;
+
+            stop0 = { groupId: `${user0Group._id}`, stopId: "3rdAveAndPike"};
+            stop1 = { groupId: `${user1Group._id}`, stopId: "3rdAveAndPike"};
         });
-        // to complete below here!
+        describe('POST /', () => {
+          it('allows the same stopId for different groups', async () => {
+            const res = await request(server)
+              .post("/stops")
+              .set('Authorization', 'Bearer ' + token0)
+              .send(stop0);
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toMatchObject(stop0);
+            const res2 = await request(server)
+              .post("/stops")
+              .set('Authorization', 'Bearer ' + token1)
+              .send(stop1);
+            expect(res2.statusCode).toEqual(200);
+            expect(res2.body).toMatchObject(stop1);
+          });
+          it('it does not allow a duplicate stopIds for the same group', async () => {
+            const res = await request(server)
+              .post("/stops")
+              .set('Authorization', 'Bearer ' + token0)
+              .send(stop0);
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toMatchObject(stop0);
+            const res2 = await request(server)
+              .post("/stops")
+              .set('Authorization', 'Bearer ' + token0)
+              .send(stop0);
+            expect(res2.statusCode).toEqual(409);
+          });
+        });
+        describe('GET /', () => {
+          let user0Stop;
+          let user1Stop;
+          beforeEach(async () => {
+            user0Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token0).send(stop0)).body;
+            user1Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token1).send(stop1)).body;
+          });
+          it('should get a stop via the groupId query', async () => {
+            const searchTerm = user0Group._id;
+            const res = await request(server)
+              .get("/stops?groupId=" + encodeURI(searchTerm))
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toEqual([user0Stop]);
+          });
+          it('should get all stops', async () => {
+            const res = await request(server)
+              .get("/stops")
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toEqual([
+              user0Stop,
+              user1Stop
+            ]);
+          });
+        });
+        describe('GET /:id', () => {
+          let user0Stop;
+          let user1Stop;
+          beforeEach(async () => {
+            user0Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token0).send(stop0)).body;
+            user1Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token1).send(stop1)).body;
+          });
+          it('should return 400 with a bad id', async () => {
+            const res = await request(server)
+              .get("/stops/123")
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.statusCode).toEqual(400);
+          });
+          it('should return user0Stop but not user1Stop', async () => {
+            const res = await request(server)
+              .get("/stops/" + user0Stop._id)
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.status).toEqual(200);
+            expect(res.body).toEqual(user0Stop);
+          });
+        });
+        describe('PUT /:id', () => {
+          let user0Stop;
+          let user1Stop;
+          beforeEach(async () => {
+            user0Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token0).send(stop0)).body;
+            user1Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token1).send(stop1)).body;
+          });
+          it('should return 400 with a bad id', async () => {
+            const res = await request(server)
+              .put("/stops/123")
+              .set('Authorization', 'Bearer ' + token0)
+              .send({stopId: "newStop"});
+            expect(res.statusCode).toEqual(400);
+          });
+          it('should update user0Stop but not user1Stop', async () => {
+            const res = await request(server)
+              .put("/stops/" + user0Stop._id)
+              .set('Authorization', 'Bearer ' + token0)
+              .send({stopId: "newStop"});
+            expect(res.status).toEqual(200);
+            const storedUser0Stop = (await request(server)
+              .get("/stops/" + user0Stop._id)
+              .set('Authorization', 'Bearer ' + token0)
+              .send()).body;
+            expect(storedUser0Stop).toMatchObject({
+              groupId: user0Group._id,
+              stopId: "newStop"
+            });
+          });
+        });
+        describe('DELETE /:id', () => {
+          let user0Stop;
+          let user1Stop;
+          beforeEach(async () => {
+            user0Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token0).send(stop0)).body;
+            user1Stop = (await request(server).post("/stops").set('Authorization', 'Bearer ' + token1).send(stop1)).body;
+          });
+          it('should return 400 with a bad id', async () => {
+            const res = await request(server)
+              .delete("/stops/123")
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.statusCode).toEqual(400);
+          });
+          it('should delete user0Stop but not user1Stop', async () => {
+            const res = await request(server)
+              .delete("/stops/" + user0Stop._id)
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(res.statusCode).toEqual(200);
+            const storedStopResponse = await request(server)
+              .get("/stops/" + user0Stop._id)
+              .set('Authorization', 'Bearer ' + token0)
+              .send();
+            expect(storedStopResponse.status).toEqual(404);
+            const storedUser1Stop = await request(server)
+              .get("/stops/" + user1Stop._id)
+              .set('Authorization', 'Bearer ' + token1)
+              .send();
+            expect(storedUser1Stop.status).toEqual(200);
+            expect(storedUser1Stop.body).toEqual(user1Stop);
+          });
+        });
     });
 });

--- a/routes/stops.test.js
+++ b/routes/stops.test.js
@@ -9,6 +9,92 @@ describe("/stops", () => {
   
     afterEach(testUtils.clearDB);
 
-    // to complete
-
+    describe('Before login', () => {
+        describe('POST /', () => {
+          it('should send 401 without a token', async () => {
+            const res = await request(server).post("/stops").send();
+            expect(res.statusCode).toEqual(401);
+          });
+          it('should send 401 with a bad token', async () => {
+            const res = await request(server)
+              .post("/stops")
+              .set('Authorization', 'Bearer BAD')
+              .send();
+            expect(res.statusCode).toEqual(401);
+          });
+        });
+        describe('GET /', () => {
+          it('should send 401 without a token', async () => {
+            const res = await request(server).get("/stops").send();
+            expect(res.statusCode).toEqual(401);
+          });
+          it('should send 401 with a bad token', async () => {
+            const res = await request(server)
+              .get("/stops")
+              .set('Authorization', 'Bearer BAD')
+              .send();
+            expect(res.statusCode).toEqual(401);
+          });
+        });
+        describe('GET /:id', () => {
+          it('should send 401 without a token', async () => {
+            const res = await request(server).get("/stops/123").send();
+            expect(res.statusCode).toEqual(401);
+          });
+          it('should send 401 with a bad token', async () => {
+            const res = await request(server)
+              .get("/stops/456")
+              .set('Authorization', 'Bearer BAD')
+              .send();
+            expect(res.statusCode).toEqual(401);
+          });
+        });
+        describe('PUT /:id', () => {
+          it('should send 401 without a token', async () => {
+            const res = await request(server).put("/stops/123").send();
+            expect(res.statusCode).toEqual(401);
+          });
+          it('should send 401 with a bad token', async () => {
+            const res = await request(server)
+              .put("/stops/456")
+              .set('Authorization', 'Bearer BAD')
+              .send();
+            expect(res.statusCode).toEqual(401);
+          });
+        });
+        describe('DELETE /:id', () => {
+          it('should send 401 without a token', async () => {
+            const res = await request(server).delete("/stops/123").send();
+            expect(res.statusCode).toEqual(401);
+          });
+          it('should send 401 with a bad token', async () => {
+            const res = await request(server)
+              .delete("/stops/456")
+              .set('Authorization', 'Bearer BAD')
+              .send();
+            expect(res.statusCode).toEqual(401);
+          });
+        });
+      });
+    describe('after login', () => {
+        const user0 = {
+            email: 'user0@mail.com',
+            password: '123password'
+        };
+        const user1 = {
+            email: 'user1@mail.com',
+            password: '456password'
+        }
+        let token0;
+        let token1;
+        beforeEach(async () => {
+            await request(server).post("/login/signup").send(user0);
+            const res0 = await request(server).post("/login").send(user0);
+            token0 = res0.body.token;
+            await request(server).post("/login/signup").send(user1);
+            const res1 = await request(server).post("/login").send(user1);
+            token1 = res1.body.token;
+        });
+        // to complete below here!
+    });
 });

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,6 +1,5 @@
 const mongoose = require('mongoose');
 const models = [
-  require('./models/authentication'),
   require('./models/bus'),
   require('./models/group'),
   require('./models/stop'),


### PR DESCRIPTION
This PR includes:

- removal of redundant authentication model and removal of reference from test-setup
- stop model including indexing to ensure that stopId is unique to the group
- CRUD routes including query
- DAO
- tests suite
- minor refactor of verifying that `:id` is a valid mongo ObjectID - also applied that to group routes

Please let me know if you have any questions.
