### PR TITLE
Adds OneBusAway API routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ONE_BUS_AWAY_API_KEY=''

--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,6 +2090,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -4428,6 +4433,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz",
       "integrity": "sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg=="
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "bcrypt": "^5.0.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "mongoose": "^5.9.21"
+    "mongoose": "^5.9.21",
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.5",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,11 @@
 const { Router } = require("express");
 const router = Router();
+require('dotenv').config();
 
-router.use("/login", require('./login'))
+router.use("/login", require('./login'));
 router.use("/groups", require('./groups'));
 router.use("/stops", require('./stops'));
 router.use("/buses", require('./buses'));
+router.use("/oba", require('./oba'));
 
 module.exports = router;

--- a/routes/oba.js
+++ b/routes/oba.js
@@ -1,0 +1,52 @@
+const { Router, query } = require("express");
+const router = Router();
+const { isAuthorized } = require("./middleware.js")
+const fetch   = require('node-fetch');
+
+const BASE_URI = 'http://api.pugetsound.onebusaway.org'
+
+router.get("/routes/:id/stops",
+  async (req, res, next) => {
+    const { id } = req.params;
+    fetch(`${BASE_URI}/api/where/stops-for-route/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
+      .then(res => res.json())
+      .then(data => {
+        res.send({ data });
+      })
+      .catch(err => {
+        res.send(err);
+      })
+  }
+);
+
+router.get("/routes/:id",
+  async (req, res, next) => {
+    const { id } = req.params;
+    fetch(`${BASE_URI}/api/where/routes-for-agency/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
+      .then(res => res.json())
+      .then(data => {
+        res.send({ data });
+      })
+      .catch(err => {
+        res.send(err);
+      })
+  }
+);
+
+
+router.get("/stops/:id/arrivals",
+  async (req, res, next) => {
+    const { id } = req.params;
+    fetch(`${BASE_URI}/api/where/arrivals-and-departures-for-stop/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
+      .then(res => res.json())
+      .then(data => {
+        res.send({ data });
+      })
+      .catch(err => {
+        res.send(err);
+      })
+  }
+);
+
+
+module.exports = router;

--- a/routes/oba.js
+++ b/routes/oba.js
@@ -1,11 +1,12 @@
 const { Router, query } = require("express");
 const router = Router();
 const { isAuthorized } = require("./middleware.js")
-const fetch   = require('node-fetch');
+const fetch = require('node-fetch');
 
 const BASE_URI = 'http://api.pugetsound.onebusaway.org'
 
 router.get("/routes/:id/stops",
+  isAuthorized,
   async (req, res, next) => {
     const { id } = req.params;
     fetch(`${BASE_URI}/api/where/stops-for-route/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
@@ -20,6 +21,7 @@ router.get("/routes/:id/stops",
 );
 
 router.get("/routes/:id",
+  isAuthorized,
   async (req, res, next) => {
     const { id } = req.params;
     fetch(`${BASE_URI}/api/where/routes-for-agency/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
@@ -33,8 +35,8 @@ router.get("/routes/:id",
   }
 );
 
-
 router.get("/stops/:id/arrivals",
+  isAuthorized,
   async (req, res, next) => {
     const { id } = req.params;
     fetch(`${BASE_URI}/api/where/arrivals-and-departures-for-stop/${id}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`)
@@ -47,6 +49,5 @@ router.get("/stops/:id/arrivals",
       })
   }
 );
-
 
 module.exports = router;

--- a/routes/oba.test.js
+++ b/routes/oba.test.js
@@ -1,0 +1,120 @@
+const request = require("supertest");
+
+const server = require("../server");
+
+const testUtils = require('../test-utils');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch', () => jest.fn());
+fetch.mockReturnValue(Promise.resolve({}));
+
+describe("/oba", () => {
+  beforeAll(testUtils.connectDB);
+  afterAll(testUtils.stopDB);
+
+  afterEach(testUtils.clearDB);
+
+  describe('Before login', () => {
+    describe('GET /routes/:id', () => {
+      it('should send 401 without a token', async () => {
+        const res = await request(server).get("/oba/routes/1").send();
+        expect(res.statusCode).toEqual(401);
+      });
+      it('should send 401 with a bad token', async () => {
+        const res = await request(server)
+          .get("/oba/routes/1")
+          .set('Authorization', 'Bearer BAD')
+          .send();
+        expect(res.statusCode).toEqual(401);
+      });
+    });
+    describe('GET /routes/:id/stops', () => {
+      it('should send 401 without a token', async () => {
+        const res = await request(server).get("/oba/routes/1/stops").send();
+        expect(res.statusCode).toEqual(401);
+      });
+      it('should send 401 with a bad token', async () => {
+        const res = await request(server)
+          .get("/oba/routes/1/stops")
+          .set('Authorization', 'Bearer BAD')
+          .send();
+        expect(res.statusCode).toEqual(401);
+      });
+    });
+    describe('GET /stops/:id/arrivals', () => {
+      it('should send 401 without a token', async () => {
+        const res = await request(server).get("/oba/stops/1/arrivals").send();
+        expect(res.statusCode).toEqual(401);
+      });
+      it('should send 401 with a bad token', async () => {
+        const res = await request(server)
+          .get("/oba/stops/1/arrivals")
+          .set('Authorization', 'Bearer BAD')
+          .send();
+        expect(res.statusCode).toEqual(401);
+      });
+    });
+  });
+  describe('after login', () => {
+    const user0 = {
+      email: 'user0@mail.com',
+      password: '123password'
+    };
+    const oneBusAwayBaseUri = 'http://api.pugetsound.onebusaway.org/api/where';
+    let token;
+    beforeEach(async () => {
+      await request(server).post("/login/signup").send(user0);
+      const res = await request(server).post("/login").send(user0);
+      token = res.body.token;
+      fetch.mockClear();
+    });
+    describe('GET /routes/:id', () => {
+      const agencyId = '5';
+      it('should send 200', async () => {
+        const res = await request(server)
+          .get(`/oba/routes/${agencyId}`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(res.statusCode).toEqual(200);
+      });
+      it('should send a request to the expected one bus away API', async () => {
+        const expectedRequest = `${oneBusAwayBaseUri}/routes-for-agency/${agencyId}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`
+        const res = await request(server)
+          .get(`/oba/routes/${agencyId}`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(fetch.mock.calls[0][0]).toBe(expectedRequest);
+      });
+    });
+    describe('GET /routes/:id/stops', () => {
+      const routeId = '9';
+      it('should send 200', async () => {
+        const res = await request(server)
+          .get(`/oba/routes/${routeId}/stops`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(res.statusCode).toEqual(200);
+      });
+      it('should send a request to the expected one bus away API', async () => {
+        const expectedRequest = `${oneBusAwayBaseUri}/stops-for-route/${routeId}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`
+        const res = await request(server)
+          .get(`/oba/routes/${routeId}/stops`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(fetch.mock.calls[0][0]).toBe(expectedRequest);
+      });
+    });
+    describe('GET /stops/:id/arrivals', () => {
+      const stopId = '3';
+      it('should send 200', async () => {
+        const res = await request(server)
+          .get(`/oba/stops/${stopId}/arrivals`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(res.statusCode).toEqual(200);
+      });
+      it('should send a request to the expected one bus away API', async () => {
+        const expectedRequest = `${oneBusAwayBaseUri}/arrivals-and-departures-for-stop/${stopId}.json?key=${process.env.ONE_BUS_AWAY_API_KEY}`
+        const res = await request(server)
+          .get(`/oba/stops/${stopId}/arrivals`)
+          .set('Authorization', 'Bearer ' + token)
+        expect(fetch.mock.calls[0][0]).toBe(expectedRequest);
+      });
+    });
+  });
+});


### PR DESCRIPTION
closes #9 

- Adds OneBusAway routes and tests.
- Adds `dotenv` to handle secrets.
- Adds `node-fetch` to handle calls to external API.